### PR TITLE
Fix untextured rendering

### DIFF
--- a/src/MphRead/Metadata.cs
+++ b/src/MphRead/Metadata.cs
@@ -3539,7 +3539,6 @@ namespace MphRead
             /* 10 */ ("pick_wpn_mortar", 0.481933594f),
             /* 11 */ ("pick_wpn_ghostbuster", 0.606933594f),
             /* 12 */ ("pick_wpn_gorea", 0.406982422f),
-            // todo: dedup?
             /* 13 */ ("pick_ammo_green", 0.307128906f),
             /* 14 */ ("pick_ammo_green", 0.307128906f),
             /* 15 */ ("pick_ammo_orange", 0.375732422f),

--- a/src/MphRead/Read.cs
+++ b/src/MphRead/Read.cs
@@ -279,7 +279,7 @@ namespace MphRead
                         JumpPadEntityData data = ReadStruct<JumpPadEntityData>(bytes[start..end]);
                         entities.Add(new Entity<JumpPadEntityData>(entry, type, init.SomeId, data));
                     }
-                    else if (type == EntityType.Item || type == EntityType.Pickup)
+                    else if (type == EntityType.Item)
                     {
                         Debug.Assert(entry.Length == Sizes.ItemEntityData);
                         ItemEntityData data = ReadStruct<ItemEntityData>(bytes[start..end]);

--- a/src/MphRead/Renderer.cs
+++ b/src/MphRead/Renderer.cs
@@ -77,7 +77,6 @@ namespace MphRead
         public float _roomScale = 1;
 
         private bool _showTextures = true;
-        private bool _showUntextured = false;
         private bool _showColors = true;
         private bool _wireframe = false;
         private bool _faceCulling = true;
@@ -172,7 +171,6 @@ namespace MphRead
             Console.WriteLine(" - Scroll mouse wheel to zoom");
             Console.WriteLine(" - Hold left mouse button to rotate");
             Console.WriteLine($" - T toggles texturing ({FormatOnOff(_showTextures)})");
-            Console.WriteLine($" - U toggles showing untextured objects ({FormatOnOff(_showUntextured)})");
             Console.WriteLine($" - C toggles vertex colours ({FormatOnOff(_showColors)})");
             Console.WriteLine($" - Q toggles wireframe ({FormatOnOff(_wireframe)})");
             Console.WriteLine($" - B toggles face culling ({FormatOnOff(_faceCulling)})");
@@ -513,10 +511,6 @@ namespace MphRead
                     {
                         continue;
                     }
-                    if (material.TextureId == UInt16.MaxValue && !_showUntextured)
-                    {
-                        continue;
-                    }
                     GL.Uniform1(_shaderLocations.IsBillboard, node.Type == 1 ? 1 : 0);
                     RenderMesh(model, mesh, material);
                 }
@@ -841,11 +835,6 @@ namespace MphRead
                 {
                     GL.Disable(EnableCap.Texture2D);
                 }
-                PrintMenu();
-            }
-            else if (e.Key == Key.U)
-            {
-                _showUntextured = !_showUntextured;
                 PrintMenu();
             }
             else if (e.Key == Key.C)

--- a/src/MphRead/SceneSetup.cs
+++ b/src/MphRead/SceneSetup.cs
@@ -55,7 +55,7 @@ namespace MphRead
             foreach (Node node in model.Nodes)
             {
                 // todo: there's probably some node or mesh property that hides these things
-                if (node.Name == "etagDoorN" || node.Name == "etagDoorS")
+                if (node.Name.Contains("etagDoor"))
                 {
                     node.Enabled = false;
                     continue;
@@ -187,12 +187,11 @@ namespace MphRead
                 else if (entity.Type == EntityType.Pickup)
                 {
                     // todo: pickups? delayed items?
-                    ItemEntityData data = ((Entity<ItemEntityData>)entity).Data;
                 }
             }
             return models;
         }
-
+        
         // todo: avoid loading things multiple times
         private static IReadOnlyList<Model> LoadJumpPad(JumpPadEntityData data)
         {

--- a/src/MphRead/SceneSetup.cs
+++ b/src/MphRead/SceneSetup.cs
@@ -52,8 +52,18 @@ namespace MphRead
 
         private static void FilterNodes(Model model, int layerMask)
         {
-            foreach (Node node in model.Nodes.Where(b => b.Name.StartsWith("_")))
+            foreach (Node node in model.Nodes)
             {
+                // todo: there's probably some node or mesh property that hides these things
+                if (node.Name == "etagDoorN" || node.Name == "etagDoorS")
+                {
+                    node.Enabled = false;
+                    continue;
+                }
+                if (!node.Name.StartsWith("_"))
+                {
+                    continue;
+                }
                 int flags = 0;
                 // we actually have to step through 4 characters at a time rather than using Contains,
                 // based on the game's behavior with e.g. "_ml_s010blocks", which is not visible in SP or MP;

--- a/src/MphRead/SceneSetup.cs
+++ b/src/MphRead/SceneSetup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenToolkit.Mathematics;
 
 namespace MphRead
@@ -191,7 +190,7 @@ namespace MphRead
             }
             return models;
         }
-        
+
         // todo: avoid loading things multiple times
         private static IReadOnlyList<Model> LoadJumpPad(JumpPadEntityData data)
         {


### PR DESCRIPTION
Remove the untextured render toggle, since there are real meshes that are supposed to be rendered without a texture (health pickup diamond). Forcibly hide `etagDoor` nodes until I can find some node/mesh property that controls them.