### PR TITLE
Fix UV animations in Blender (0.10.4.0)

### DIFF
--- a/src/MphRead/Export/Modules/mph_common.py
+++ b/src/MphRead/Export/Modules/mph_common.py
@@ -2,7 +2,7 @@ import bpy
 import mathutils
 
 def get_common_version():
-    return '0.10.3.0'
+    return '0.11.0.0'
 
 def get_object(name):
     try:

--- a/src/MphRead/Program.cs
+++ b/src/MphRead/Program.cs
@@ -9,7 +9,7 @@ namespace MphRead
 {
     internal static class Program
     {
-        public static Version Version { get; } = new Version(0, 11, 0, 0);
+        public static Version Version { get; } = new Version(0, 10, 4, 0);
 
         private static void Main(string[] args)
         {

--- a/src/MphRead/Program.cs
+++ b/src/MphRead/Program.cs
@@ -9,7 +9,7 @@ namespace MphRead
 {
     internal static class Program
     {
-        public static Version Version { get; } = new Version(0, 10, 3, 0);
+        public static Version Version { get; } = new Version(0, 11, 0, 0);
 
         private static void Main(string[] args)
         {


### PR DESCRIPTION
- Import UV animations with vector math nodes in the shader instead of the UV Warp modifier on the objects