### PR TITLE
Merge develop (0.16.1.0)

### DIFF
--- a/src/MphRead/Entities/EntityBase.cs
+++ b/src/MphRead/Entities/EntityBase.cs
@@ -231,7 +231,12 @@ namespace MphRead.Entities
             model.UpdateMatrixStack(scene.ViewInvRotMatrix, scene.ViewInvRotYMatrix);
             // todo: could skip this unless a relevant material property changed this update (and we're going to draw this entity)
             scene.UpdateMaterials(model, GetModelRecolor(inst, index));
-            UpdateCollision();
+            if (scene.ShowCollision)
+            {
+                // if collision is not shown, the "needs update" state will persist until it is
+                // --> this is fine since _colPoints are only for display, not detection
+                UpdateCollision();
+            }
         }
 
         public virtual void GetDrawInfo(Scene scene)

--- a/src/MphRead/Export/Modules/mph_common.py
+++ b/src/MphRead/Export/Modules/mph_common.py
@@ -2,7 +2,7 @@ import bpy
 import mathutils
 
 def get_common_version():
-    return '0.16.0.0'
+    return '0.16.1.0'
 
 def get_object(name):
     try:

--- a/src/MphRead/Formats/NodeData.cs
+++ b/src/MphRead/Formats/NodeData.cs
@@ -28,9 +28,11 @@ namespace MphRead.Formats
             ushort version = Read.SpanReadUshort(bytes, 0);
             if (version == 0)
             {
+                // todo: this
                 ReadFhNodeData(bytes);
                 return null!;
             }
+            // todo: version 4 (unit2_Land_Node.bin)
             if (version != 6)
             {
                 throw new ProgramException($"Unexpected node data version {version}.");

--- a/src/MphRead/Metadata/Rooms.cs
+++ b/src/MphRead/Metadata/Rooms.cs
@@ -813,7 +813,7 @@ namespace MphRead
                         collisionPath: "unit1_c4_collision.bin",
                         texturePath: "unit1_c4_tex.bin",
                         entityPath: "Unit1_C4_Ent.bin",
-                        nodePath: "unit1_C4_Node.bin",
+                        nodePath: null, // metadata has unit1_C4_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -933,7 +933,7 @@ namespace MphRead
                         collisionPath: "TeleportRoom_collision.bin",
                         texturePath: "teleportroom_tex.bin",
                         entityPath: "Unit1_TP1_Ent.bin",
-                        nodePath: "unit1_TP1_Node.bin",
+                        nodePath: null, // metadata has unit1_TP1_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -1203,7 +1203,7 @@ namespace MphRead
                         collisionPath: "TeleportRoom_collision.bin",
                         texturePath: "teleportroom_tex.bin",
                         entityPath: "Unit1_TP2_Ent.bin",
-                        nodePath: "unit1_TP2_Node.bin",
+                        nodePath: null, // metadata has unit1_TP2_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -1533,7 +1533,7 @@ namespace MphRead
                         collisionPath: "TeleportRoom_collision.bin",
                         texturePath: "teleportroom_tex.bin",
                         entityPath: "Unit2_TP1_Ent.bin",
-                        nodePath: "unit2_TP1_Node.bin",
+                        nodePath: null, // metadata has unit2_TP1_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -1803,7 +1803,7 @@ namespace MphRead
                         collisionPath: "TeleportRoom_collision.bin",
                         texturePath: "teleportroom_tex.bin",
                         entityPath: "Unit2_TP2_Ent.bin",
-                        nodePath: "unit2_TP2_Node.bin",
+                        nodePath: null, // metadata has unit2_TP2_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -2013,7 +2013,7 @@ namespace MphRead
                         collisionPath: "TeleportRoom_collision.bin",
                         texturePath: "teleportroom_tex.bin",
                         entityPath: "Unit3_TP1_Ent.bin",
-                        nodePath: "unit3_TP1_Node.bin",
+                        nodePath: null, // metadata has unit3_TP1_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -2163,7 +2163,7 @@ namespace MphRead
                         collisionPath: "TeleportRoom_collision.bin",
                         texturePath: "teleportroom_tex.bin",
                         entityPath: "Unit3_TP2_Ent.bin",
-                        nodePath: "unit3_TP2_Node.bin",
+                        nodePath: null, // metadata has unit3_TP2_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -2343,7 +2343,7 @@ namespace MphRead
                         collisionPath: "TeleportRoom_collision.bin",
                         texturePath: "teleportroom_tex.bin",
                         entityPath: "Unit4_TP1_Ent.bin",
-                        nodePath: "unit4_TP1_Node.bin",
+                        nodePath: null, // metadata has unit4_TP1_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -2403,7 +2403,7 @@ namespace MphRead
                         collisionPath: "unit4_c1_collision.bin",
                         texturePath: "unit4_c1_tex.bin",
                         entityPath: "unit4_C1_Ent.bin",
-                        nodePath: "unit4_c1_Node.bin",
+                        nodePath: null, // metadata has unit4_c1_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(10, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -2523,7 +2523,7 @@ namespace MphRead
                         collisionPath: "TeleportRoom_collision.bin",
                         texturePath: "teleportroom_tex.bin",
                         entityPath: "Unit4_TP2_Ent.bin",
-                        nodePath: "unit4_TP2_Node.bin",
+                        nodePath: null, // metadata has unit4_TP2_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),
@@ -2583,7 +2583,7 @@ namespace MphRead
                         collisionPath: "Gorea_Land_collision.bin",
                         texturePath: "Gorea_Land_tex.bin",
                         entityPath: "Gorea_Land_Ent.bin",
-                        nodePath: "Gorea_Land_Node.bin",
+                        nodePath: null,// metadata has Gorea_Land_Node.bin, but there's no such file
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),

--- a/src/MphRead/Metadata/Rooms.cs
+++ b/src/MphRead/Metadata/Rooms.cs
@@ -1263,7 +1263,7 @@ namespace MphRead
                         collisionPath: "unit2_Land_collision.bin",
                         texturePath: "unit2_land_tex.bin",
                         entityPath: "unit2_Land_Ent.bin",
-                        nodePath: "unit2_Land_Node.bin",
+                        nodePath: null, // metadata has unit2_Land_Node.bin, but it's version 4 (won't load anyway due to no bots)
                         roomNodeName: null,
                         battleTimeLimit: TimeLimit(40, 0, 0),
                         timeLimit: TimeLimit(4, 0, 0),

--- a/src/MphRead/Program.cs
+++ b/src/MphRead/Program.cs
@@ -9,7 +9,7 @@ namespace MphRead
 {
     internal static class Program
     {
-        public static Version Version { get; } = new Version(0, 16, 0, 0);
+        public static Version Version { get; } = new Version(0, 16, 1, 0);
 
         private static void Main(string[] args)
         {


### PR DESCRIPTION
- Fix invalid nodedata paths
- Don't update collision vertices unless collision display is enabled