### PR TITLE
Merge develop (0.22.1.0)

### DIFF
--- a/src/MphRead/Entities/BeamEffectEntity.cs
+++ b/src/MphRead/Entities/BeamEffectEntity.cs
@@ -84,6 +84,7 @@ namespace MphRead.Entities
         public override void Destroy()
         {
             _scene.UnlinkBeamEffect(this);
+            base.Destroy();
         }
 
         public static BeamEffectEntity? Create(BeamEffectEntityData data, Scene scene)

--- a/src/MphRead/Entities/BeamProjectileEntity.cs
+++ b/src/MphRead/Entities/BeamProjectileEntity.cs
@@ -1344,6 +1344,7 @@ namespace MphRead.Entities
             RicochetWeapon = null;
             Equip = null;
             _trailModel = null;
+            base.Destroy();
         }
 
         private static BeamProjectileEntity ChooseBeamSlot(EquipInfo equip, EntityBase owner)

--- a/src/MphRead/Entities/BombEntity.cs
+++ b/src/MphRead/Entities/BombEntity.cs
@@ -626,6 +626,7 @@ namespace MphRead.Entities
             Effect = null;
             Owner = null!;
             _scene.UnlinkBomb(this);
+            base.Destroy();
         }
 
         public void PlaySpawnSfx()

--- a/src/MphRead/Entities/DoorEntity.cs
+++ b/src/MphRead/Entities/DoorEntity.cs
@@ -504,6 +504,7 @@ namespace MphRead.Entities
             Portal = null;
             ConnectorModel = null;
             ConnectorCollision = null;
+            base.Destroy();
         }
 
         public override void GetDrawInfo()

--- a/src/MphRead/Entities/Enemies/11_Shriekbat.cs
+++ b/src/MphRead/Entities/Enemies/11_Shriekbat.cs
@@ -178,6 +178,7 @@ namespace MphRead.Entities.Enemies
                 _scene.UnlinkEffectEntry(_effect);
                 _effect = null;
             }
+            base.Destroy();
         }
 
         #region Boilerplate

--- a/src/MphRead/Entities/Enemies/23_PsychoBit.cs
+++ b/src/MphRead/Entities/Enemies/23_PsychoBit.cs
@@ -625,6 +625,7 @@ namespace MphRead.Entities.Enemies
                 _scene.UnlinkEffectEntry(_effect);
                 _effect = null;
             }
+            base.Destroy();
         }
 
         #region Boilerplate

--- a/src/MphRead/Entities/Enemies/39_FireSpawn.cs
+++ b/src/MphRead/Entities/Enemies/39_FireSpawn.cs
@@ -411,6 +411,7 @@ namespace MphRead.Entities.Enemies
                 _scene.UnlinkEffectEntry(_effectEntry);
                 _effectEntry = null;
             }
+            base.Destroy();
         }
 
         #region Boilerplate

--- a/src/MphRead/Entities/EnemyInstanceEntity.cs
+++ b/src/MphRead/Entities/EnemyInstanceEntity.cs
@@ -364,6 +364,7 @@ namespace MphRead.Entities
                 unaffected = true;
             }
             bool dead = false;
+            bool doubleDead = false;
             if (!unaffected)
             {
                 if (beamSource?.Owner?.Type == EntityType.Player)
@@ -377,6 +378,10 @@ namespace MphRead.Entities
                 if (damage >= _health)
                 {
                     dead = true;
+                    if (_health <= 0)
+                    {
+                        doubleDead = true;
+                    }
                     _health = 0;
                 }
                 else
@@ -406,6 +411,10 @@ namespace MphRead.Entities
             }
             else
             {
+                if (doubleDead && Bugfixes.NoDoubleEnemyDeath)
+                {
+                    return;
+                }
                 if (beamSource != null)
                 {
                     beamSource.SpawnDamageEffect(effectiveness);

--- a/src/MphRead/Entities/ItemInstanceEntity.cs
+++ b/src/MphRead/Entities/ItemInstanceEntity.cs
@@ -183,6 +183,7 @@ namespace MphRead.Entities
                 _scene.UnlinkEffectEntry(_effectEntry);
             }
             _soundSource.StopAllSfx(force: true);
+            base.Destroy();
         }
     }
 

--- a/src/MphRead/Entities/ObjectEntity.cs
+++ b/src/MphRead/Entities/ObjectEntity.cs
@@ -268,7 +268,7 @@ namespace MphRead.Entities
                         needsUpdate = false;
                     }
                 }
-                else if (_data.ModelId == 53) // WallSwitch
+                else if (_data.ModelId == 53 && state == 1) // WallSwitch
                 {
                     _models[0].SetAnimation(animId, AnimFlags.NoLoop);
                     _soundSource.PlayFreeSfx(SfxId.F2_SWITCH);

--- a/src/MphRead/Entities/ObjectEntity.cs
+++ b/src/MphRead/Entities/ObjectEntity.cs
@@ -149,6 +149,7 @@ namespace MphRead.Entities
             {
                 _scene.UnlinkEffectEntry(_effectEntry);
             }
+            base.Destroy();
         }
 
         private void UpdateVisiblePosition()

--- a/src/MphRead/Entities/ObjectEntity.cs
+++ b/src/MphRead/Entities/ObjectEntity.cs
@@ -76,7 +76,6 @@ namespace MphRead.Entities
                 }
                 Recolor = _meta.RecolorId;
                 ModelInstance inst = SetUpModel(_meta.Name);
-                _state = (int)(_flags & ObjectFlags.State);
                 int animIndex = _meta.AnimationIds[_state];
                 // AlimbicCapsule
                 if (data.ModelId == 45)

--- a/src/MphRead/Entities/PlatformEntity.cs
+++ b/src/MphRead/Entities/PlatformEntity.cs
@@ -354,6 +354,7 @@ namespace MphRead.Entities
                     _scene.UnlinkEffectEntry(effectEntry);
                 }
             }
+            base.Destroy();
         }
 
         public override void GetPosition(out Vector3 position)

--- a/src/MphRead/Entities/Players/HalfturretEntity.cs
+++ b/src/MphRead/Entities/Players/HalfturretEntity.cs
@@ -340,6 +340,7 @@ namespace MphRead.Entities
                 _scene.UnlinkEffectEntry(_burnEffect);
                 _burnEffect = null;
             }
+            base.Destroy();
         }
 
         public override void GetDrawInfo()

--- a/src/MphRead/Entities/Players/PlayerProcess.cs
+++ b/src/MphRead/Entities/Players/PlayerProcess.cs
@@ -2091,6 +2091,7 @@ namespace MphRead.Entities
                 _scene.UnlinkEffectEntry(_deathaltEffect);
                 _deathaltEffect = null;
             }
+            base.Destroy();
         }
     }
 }

--- a/src/MphRead/Entities/TeleporterEntity.cs
+++ b/src/MphRead/Entities/TeleporterEntity.cs
@@ -343,6 +343,7 @@ namespace MphRead.Entities
         public override void Destroy()
         {
             _soundSource.StopAllSfx(force: true);
+            base.Destroy();
         }
 
         protected override Matrix4 GetModelTransform(ModelInstance inst, int index)

--- a/src/MphRead/Export/Modules/mph_common.py
+++ b/src/MphRead/Export/Modules/mph_common.py
@@ -2,7 +2,7 @@ import bpy
 import mathutils
 
 def get_common_version():
-    return '0.22.0.0'
+    return '0.22.1.0'
 
 def get_object(name):
     try:

--- a/src/MphRead/Features.cs
+++ b/src/MphRead/Features.cs
@@ -6,6 +6,7 @@ namespace MphRead
         public static bool BetterCamSeqNodeRef { get; set; } = true;
         public static bool NoStrayRespawnText { get; set; } = false;
         public static bool CorrectBountySfx { get; set; } = true;
+        public static bool NoDoubleEnemyDeath { get; set; } = true;
     }
 
     public static class Features

--- a/src/MphRead/MphRead.csproj
+++ b/src/MphRead/MphRead.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.7" />
+    <PackageReference Include="OpenTK" Version="4.8.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/MphRead/MphRead.csproj
+++ b/src/MphRead/MphRead.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.1" />
+    <PackageReference Include="OpenTK" Version="4.7.7" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/MphRead/Program.cs
+++ b/src/MphRead/Program.cs
@@ -9,7 +9,7 @@ namespace MphRead
 {
     internal static class Program
     {
-        public static Version Version { get; } = new Version(0, 22, 0, 0);
+        public static Version Version { get; } = new Version(0, 22, 1, 0);
         private static readonly Version _minExtractVersion = new Version(0, 19, 0, 0);
 
         private static void Main(string[] args)

--- a/src/MphRead/Program.cs
+++ b/src/MphRead/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -22,17 +21,11 @@ namespace MphRead
             IReadOnlyList<Argument> arguments = ParseArguments(args);
             if (arguments.Count == 0)
             {
-                if (Debugger.IsAttached)
-                {
-                    using var renderer = new RenderWindow();
-                    renderer.AddRoom("MP3 PROVING GROUND");
-                    //renderer.AddModel("Crate01");
-                    renderer.Run();
-                }
-                else
-                {
-                    Menu.ShowMenuPrompts();
-                }
+                //using var renderer = new RenderWindow();
+                //renderer.AddRoom("MP3 PROVING GROUND");
+                //renderer.AddModel("Crate01");
+                //renderer.Run();
+                Menu.ShowMenuPrompts();
             }
             else if (arguments.Any(a => a.Name == "setup"))
             {

--- a/src/MphRead/Renderer.cs
+++ b/src/MphRead/Renderer.cs
@@ -4672,7 +4672,6 @@ namespace MphRead
     {
         private static readonly GameWindowSettings _gameWindowSettings = new GameWindowSettings()
         {
-            RenderFrequency = 60,
             UpdateFrequency = 60
         };
 
@@ -4735,12 +4734,9 @@ namespace MphRead
 
         protected override void OnRenderFrame(FrameEventArgs args)
         {
-            CursorGrabbed = Scene.CameraMode == CameraMode.Player
-                && !Scene.FrameAdvance && !Scene.ShowCursor && !GameState.DialogPause;
-            if (!CursorGrabbed)
-            {
-                CursorVisible = true;
-            }
+            CursorState = Scene.CameraMode == CameraMode.Player && !Scene.FrameAdvance && !Scene.ShowCursor && !GameState.DialogPause
+                ? CursorState.Grabbed
+                : CursorState.Normal;
             GameState.ApplyPause();
             Scene.OnUpdateFrame();
             if (!Scene.OnRenderFrame())

--- a/src/MphRead/Renderer.cs
+++ b/src/MphRead/Renderer.cs
@@ -464,20 +464,27 @@ namespace MphRead
 
         private void InitShaders()
         {
+            string fragmentLog;
+            string vertexLog;
             int vertexShader = GL.CreateShader(ShaderType.VertexShader);
             GL.ShaderSource(vertexShader, Shaders.VertexShader);
             GL.CompileShader(vertexShader);
-            string vertexLog = GL.GetShaderInfoLog(vertexShader);
             int fragmentShader = GL.CreateShader(ShaderType.FragmentShader);
             GL.ShaderSource(fragmentShader, Shaders.FragmentShader);
             GL.CompileShader(fragmentShader);
-            string fragmentLog = GL.GetShaderInfoLog(fragmentShader);
-            if (vertexLog != "" || fragmentLog != "")
+            GL.GetShader(vertexShader, ShaderParameter.CompileStatus, out int vertexStatus);
+            GL.GetShader(fragmentShader, ShaderParameter.CompileStatus, out int fragmentStatus);
+            if (Debugger.IsAttached)
             {
-                if (Debugger.IsAttached)
+                vertexLog = GL.GetShaderInfoLog(vertexShader);
+                fragmentLog = GL.GetShaderInfoLog(fragmentShader);
+                if (vertexLog != "" || fragmentLog != "")
                 {
                     Debugger.Break();
                 }
+            }
+            if (vertexStatus == 0 || fragmentStatus == 0)
+            {
                 throw new ProgramException("Failed to compile main shaders.");
             }
 
@@ -493,17 +500,22 @@ namespace MphRead
             vertexShader = GL.CreateShader(ShaderType.VertexShader);
             GL.ShaderSource(vertexShader, Shaders.RttVertexShader);
             GL.CompileShader(vertexShader);
-            vertexLog = GL.GetShaderInfoLog(vertexShader);
             fragmentShader = GL.CreateShader(ShaderType.FragmentShader);
             GL.ShaderSource(fragmentShader, Shaders.RttFragmentShader);
             GL.CompileShader(fragmentShader);
-            fragmentLog = GL.GetShaderInfoLog(fragmentShader);
-            if (vertexLog != "" || fragmentLog != "")
+            GL.GetShader(vertexShader, ShaderParameter.CompileStatus, out vertexStatus);
+            GL.GetShader(fragmentShader, ShaderParameter.CompileStatus, out fragmentStatus);
+            if (Debugger.IsAttached)
             {
-                if (Debugger.IsAttached)
+                vertexLog = GL.GetShaderInfoLog(vertexShader);
+                fragmentLog = GL.GetShaderInfoLog(fragmentShader);
+                if (vertexLog != "" || fragmentLog != "")
                 {
                     Debugger.Break();
                 }
+            }
+            if (vertexStatus == 0 || fragmentStatus == 0)
+            {
                 throw new ProgramException("Failed to compile RTT shaders.");
             }
             _rttShaderProgramId = GL.CreateProgram();
@@ -518,13 +530,17 @@ namespace MphRead
             fragmentShader = GL.CreateShader(ShaderType.FragmentShader);
             GL.ShaderSource(fragmentShader, Shaders.ShiftFragmentShader);
             GL.CompileShader(fragmentShader);
-            fragmentLog = GL.GetShaderInfoLog(fragmentShader);
-            if (fragmentLog != "")
+            GL.GetShader(fragmentShader, ShaderParameter.CompileStatus, out fragmentStatus);
+            if (Debugger.IsAttached)
             {
-                if (Debugger.IsAttached)
+                fragmentLog = GL.GetShaderInfoLog(fragmentShader);
+                if (fragmentLog != "")
                 {
                     Debugger.Break();
                 }
+            }
+            if (fragmentStatus == 0)
+            {
                 throw new ProgramException("Failed to compile shift shader.");
             }
             _shiftShaderProgramId = GL.CreateProgram();
@@ -4638,7 +4654,7 @@ namespace MphRead
             _sb.AppendLine($"Texture ID {material.CurrentTextureId}, Palette ID {material.CurrentPaletteId}");
             _sb.AppendLine($"Diffuse ({material.Diffuse.Red}, {material.Diffuse.Green}, {material.Diffuse.Blue})" +
                 $" Ambient ({material.Ambient.Red}, {material.Ambient.Green}, {material.Ambient.Blue})" +
-                $" Specular ({ material.Specular.Red}, { material.Specular.Green}, { material.Specular.Blue})");
+                $" Specular ({material.Specular.Red}, {material.Specular.Green}, {material.Specular.Blue})");
         }
 
         private string OnOff(bool setting)
@@ -4665,6 +4681,7 @@ namespace MphRead
             Size = new Vector2i(1024, 768),
             Title = "MphRead",
             Profile = ContextProfile.Compatability,
+            Flags = ContextFlags.Default,
             APIVersion = new Version(3, 2),
             StartVisible = false
         };

--- a/src/MphRead/Renderer.cs
+++ b/src/MphRead/Renderer.cs
@@ -4403,8 +4403,8 @@ namespace MphRead
             _sb.AppendLine(" - Hold left mouse button or use arrow keys to rotate");
             _sb.AppendLine(" - Hold Shift to move the camera faster");
             _sb.AppendLine($" - T toggles texturing ({OnOff(_showTextures)})");
-            _sb.AppendLine($" - C toggles vertex colours ({OnOff(_showColors)})");
-            _sb.AppendLine($" - Q toggles wireframe ({OnOff(_wireframe)})");
+            _sb.AppendLine($" - Ctrl+C toggles vertex colors ({OnOff(_showColors)})");
+            _sb.AppendLine($" - Ctrl+Q toggles wireframe ({OnOff(_wireframe)})");
             _sb.AppendLine($" - B toggles face culling ({OnOff(_faceCulling)})");
             _sb.AppendLine($" - F toggles texture filtering ({OnOff(_textureFiltering)})");
             _sb.AppendLine($" - L toggles lighting ({OnOff(_lighting)})");


### PR DESCRIPTION
- Add missing `base.Destroy()` calls that were causing an SFX bug (or something -- it's been a while)
- Add option to fix in-game double enemy kill bug
- Fix some object state bugs (don't remember what these were)
- Update shader compilation checks so warnings are not treated as errors
- Correct controls display for toggling vertex colors and wireframe
- Blender script: Stop using label names, which are subject to change, when finding nodes
  - This fixes scripting in current versions of Blender and should prevent it from breaking in the future
- Update OpenTK