### PR TITLE
Merge develop (0.23.1.0)

### DIFF
--- a/src/MphRead/Entities/CamSeq/CameraSequence.cs
+++ b/src/MphRead/Entities/CamSeq/CameraSequence.cs
@@ -518,7 +518,7 @@ namespace MphRead.Formats
 
         public static CameraSequence Load(string name, Scene scene, int id = -1)
         {
-            string path = Path.Combine(Paths.FileSystem, "cameraEditor", name);
+            string path = Paths.Combine(Paths.FileSystem, "cameraEditor", name);
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             CameraSequenceHeader header = Read.ReadStruct<CameraSequenceHeader>(bytes);
             Debug.Assert(header.Padding3 == 0);

--- a/src/MphRead/Export/Collada.cs
+++ b/src/MphRead/Export/Collada.cs
@@ -42,7 +42,7 @@ namespace MphRead.Export
 
         public static void ExportModel(Model model, bool transformRoom = false)
         {
-            string exportPath = Path.Combine(Paths.Export, model.Name);
+            string exportPath = Paths.Combine(Paths.Export, model.Name);
             Directory.CreateDirectory(exportPath);
             var lists = new List<Dictionary<string, IReadOnlyList<Vertex>>>();
             for (int i = 0; i < model.Recolors.Count; i++)
@@ -69,7 +69,7 @@ namespace MphRead.Export
                     }
                 }
             }
-            File.WriteAllText(Path.Combine(exportPath, $"import_{model.Name}.py"), Scripting.GenerateScript(model, lists.First()));
+            File.WriteAllText(Paths.Combine(exportPath, $"import_{model.Name}.py"), Scripting.GenerateScript(model, lists.First()));
         }
 
         private static Dictionary<string, IReadOnlyList<Vertex>> ExportRecolor(Model model, bool transformRoom, int recolorIndex)
@@ -526,8 +526,8 @@ namespace MphRead.Export
             // end
             sb.Append("\n</COLLADA>");
 
-            string exportPath = Path.Combine(Paths.Export, model.Name);
-            File.WriteAllText(Path.Combine(exportPath, $"{model.Name}_{recolor.Name}.dae"), sb.ToString());
+            string exportPath = Paths.Combine(Paths.Export, model.Name);
+            File.WriteAllText(Paths.Combine(exportPath, $"{model.Name}_{recolor.Name}.dae"), sb.ToString());
             return results;
         }
 

--- a/src/MphRead/Export/Images.cs
+++ b/src/MphRead/Export/Images.cs
@@ -31,10 +31,10 @@ namespace MphRead.Export
             }
             using var image = Image.LoadPixelData<Rgba32>(buffer, width, height);
             image.Mutate(m => RotateFlipExtensions.RotateFlip(m, RotateMode.None, FlipMode.Vertical));
-            string path = Path.Combine(Paths.Export, "_screenshots");
+            string path = Paths.Combine(Paths.Export, "_screenshots");
             Directory.CreateDirectory(path);
             name ??= DateTimeOffset.Now.ToUnixTimeMilliseconds().ToString();
-            image.SaveAsPng(Path.Combine(path, $"{name}.png"), _encoderComp);
+            image.SaveAsPng(Paths.Combine(path, $"{name}.png"), _encoderComp);
         }
 
         public static void Record(int width, int height, string name)
@@ -61,9 +61,9 @@ namespace MphRead.Export
                 while (_queue.TryDequeue(out (Image Image, string Name) result))
                 {
                     result.Image.Mutate(m => RotateFlipExtensions.RotateFlip(m, RotateMode.None, FlipMode.Vertical));
-                    string path = Path.Combine(Paths.Export, "_screenshots");
+                    string path = Paths.Combine(Paths.Export, "_screenshots");
                     Directory.CreateDirectory(path);
-                    await result.Image.SaveAsPngAsync(Path.Combine(path, $"{result.Name}.png"), _encoderUncomp);
+                    await result.Image.SaveAsPngAsync(Paths.Combine(path, $"{result.Name}.png"), _encoderUncomp);
                     result.Image.Dispose();
                 }
                 await Task.Delay(15);
@@ -72,10 +72,10 @@ namespace MphRead.Export
 
         public static void ExportImages(Model model)
         {
-            string exportPath = Path.Combine(Paths.Export, model.Name);
+            string exportPath = Paths.Combine(Paths.Export, model.Name);
             foreach (Recolor recolor in model.Recolors)
             {
-                string colorPath = Path.Combine(exportPath, recolor.Name);
+                string colorPath = Paths.Combine(exportPath, recolor.Name);
                 Directory.CreateDirectory(colorPath);
                 var usedTextures = new HashSet<int>();
                 int id = 0;
@@ -123,7 +123,7 @@ namespace MphRead.Export
                 }
                 if (usedTextures.Count != recolor.Textures.Count)
                 {
-                    string unusedPath = Path.Combine(colorPath, "unused");
+                    string unusedPath = Paths.Combine(colorPath, "unused");
                     Directory.CreateDirectory(unusedPath);
                     for (int t = 0; t < recolor.Textures.Count; t++)
                     {
@@ -151,10 +151,10 @@ namespace MphRead.Export
 
         public static void ExportPalettes(Model model)
         {
-            string exportPath = Path.Combine(Paths.Export, model.Name);
+            string exportPath = Paths.Combine(Paths.Export, model.Name);
             foreach (Recolor recolor in model.Recolors)
             {
-                string palettePath = Path.Combine(exportPath, recolor.Name, "palettes");
+                string palettePath = Paths.Combine(exportPath, recolor.Name, "palettes");
                 Directory.CreateDirectory(palettePath);
                 for (int p = 0; p < recolor.Palettes.Count; p++)
                 {
@@ -167,7 +167,7 @@ namespace MphRead.Export
 
         public static void SaveTexture(string directory, string filename, ushort width, ushort height, IReadOnlyList<ColorRgba> pixels)
         {
-            string imagePath = Path.Combine(directory, $"{filename}.png");
+            string imagePath = Paths.Combine(directory, $"{filename}.png");
             using var image = new Image<Rgba32>(width, height);
             for (int p = 0; p < pixels.Count; p++)
             {

--- a/src/MphRead/Export/Scripting.cs
+++ b/src/MphRead/Export/Scripting.cs
@@ -175,7 +175,7 @@ namespace MphRead.Export
             sb.AppendIndent();
             sb.AppendLine("cleanup()");
             sb.AppendIndent();
-            string daePath = Path.GetFullPath(Path.Combine(Paths.Export, model.Name, $"{model.Name}_{{suffix}}.dae"));
+            string daePath = Path.GetFullPath(Paths.Combine(Paths.Export, model.Name, $"{model.Name}_{{suffix}}.dae"));
             sb.AppendLine("bpy.ops.wm.collada_import(filepath =");
             sb.AppendIndent();
             sb.AppendIndent();

--- a/src/MphRead/Export/Scripting.cs
+++ b/src/MphRead/Export/Scripting.cs
@@ -391,7 +391,7 @@ bpy.ops.object.parent_set(type='ARMATURE_NAME')");
 
         public static void AppendIndent(this StringBuilder sb, string text, int indent = 1)
         {
-            foreach (string part in text.Trim().Replace("\r\n", "\n").Replace("\r", "\n").Split('\n'))
+            foreach (string part in text.Trim().Replace("\r\n", "\n").Replace('\r', '\n').Split('\n'))
             {
                 for (int i = 0; i < indent; i++)
                 {

--- a/src/MphRead/Export/Scripting.cs
+++ b/src/MphRead/Export/Scripting.cs
@@ -391,7 +391,7 @@ bpy.ops.object.parent_set(type='ARMATURE_NAME')");
 
         public static void AppendIndent(this StringBuilder sb, string text, int indent = 1)
         {
-            foreach (string part in text.Trim().Split("\r\n"))
+            foreach (string part in text.Trim().Replace("\r\n", "\n").Replace("\r", "\n").Split('\n'))
             {
                 for (int i = 0; i < indent; i++)
                 {

--- a/src/MphRead/Formats/Collision.cs
+++ b/src/MphRead/Formats/Collision.cs
@@ -64,7 +64,7 @@ namespace MphRead.Formats.Collision
             {
                 return new CollisionInstance(name, info, isEntity);
             }
-            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path)));
+            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path)));
             CollisionHeader header = Read.ReadStruct<CollisionHeader>(bytes);
             if (header.Type.MarshalString() == "wc01")
             {

--- a/src/MphRead/Formats/FhSound.cs
+++ b/src/MphRead/Formats/FhSound.cs
@@ -49,7 +49,7 @@ namespace MphRead.Formats.Sound
 
         public static IReadOnlyList<SoundSample> ReadFhSoundFile(string filename)
         {
-            string path = Path.Combine(Paths.FhFileSystem, "sound", filename);
+            string path = Paths.Combine(Paths.FhFileSystem, "sound", filename);
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint count = Read.SpanReadUint(bytes, 0);
             var samples = new List<SoundSample>();

--- a/src/MphRead/Formats/Formats.cs
+++ b/src/MphRead/Formats/Formats.cs
@@ -1513,6 +1513,43 @@ namespace MphRead
             }
             FhKey = "AMFE0";
         }
+
+        private static string Replace(string path)
+        {
+            if (Path.DirectorySeparatorChar == '\\')
+            {
+                return path.Replace('/', '\\');
+            }
+            if (Path.DirectorySeparatorChar == '/')
+            {
+                return path.Replace('\\', '/');
+            }
+            return path;
+        }
+
+        public static string Combine(string path1, string path2)
+        {
+            return Path.Combine(Replace(path1), Replace(path2));
+        }
+
+        public static string Combine(string path1, string path2, string path3)
+        {
+            return Path.Combine(Replace(path1), Replace(path2), Replace(path3));
+        }
+
+        public static string Combine(string path1, string path2, string path3, string path4)
+        {
+            return Path.Combine(Replace(path1), Replace(path2), Replace(path3), Replace(path4));
+        }
+
+        public static string Combine(params string[] paths)
+        {
+            for (int i = 0; i < paths.Length; i++)
+            {
+                paths[i] = Replace(paths[i]);
+            }
+            return Path.Combine(paths);
+        }
     }
 
     public static class CollectionExtensions

--- a/src/MphRead/Formats/NodeData.cs
+++ b/src/MphRead/Formats/NodeData.cs
@@ -12,11 +12,11 @@ namespace MphRead.Formats
     {
         public static void TestAll()
         {
-            foreach (string path in Directory.EnumerateFiles(Path.Combine(Paths.FileSystem, @"levels\nodeData")))
+            foreach (string path in Directory.EnumerateFiles(Paths.Combine(Paths.FileSystem, @"levels\nodeData")))
             {
                 if (!path.EndsWith(@"levels\nodeData\unit2_Land_Node.bin")) // todo: version 4
                 {
-                    ReadData(Path.Combine(@"levels\nodeData", Path.GetFileName(path)));
+                    ReadData(Paths.Combine(@"levels\nodeData", Path.GetFileName(path)));
                 }
             }
             Nop();
@@ -24,7 +24,7 @@ namespace MphRead.Formats
 
         public static NodeData ReadData(string path)
         {
-            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(Paths.FileSystem, path)));
+            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(Paths.FileSystem, path)));
             ushort version = Read.SpanReadUshort(bytes, 0);
             if (version == 0)
             {

--- a/src/MphRead/Formats/Sound.cs
+++ b/src/MphRead/Formats/Sound.cs
@@ -190,9 +190,9 @@ namespace MphRead.Formats.Sound
             uint headerSize = 0x2C;
             uint waveSize = sampleCount * bps / 8 + headerSize;
             uint decodedSize = sampleCount * (bps / 8);
-            string path = Path.Combine(Paths.Export, "_SFX");
+            string path = Paths.Combine(Paths.Export, "_SFX");
             Directory.CreateDirectory(path);
-            path = Path.Combine(path, $"{name}.wav");
+            path = Paths.Combine(path, $"{name}.wav");
             using FileStream file = File.OpenWrite(path);
             using var writer = new BinaryWriter(file);
             writer.WriteC("RIFF");
@@ -229,7 +229,7 @@ namespace MphRead.Formats.Sound
         // todo: confirm no unused bytes (given the padding)
         private static IReadOnlyList<SoundSample> ReadSoundSamples(string filename)
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", filename);
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", filename);
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint count = Read.SpanReadUint(bytes, 0);
             Debug.Assert(count > 0);
@@ -268,7 +268,7 @@ namespace MphRead.Formats.Sound
 
         private static IReadOnlyList<SoundSelectEntry> ReadSelectList(string filename)
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", filename);
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", filename);
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint count = Read.SpanReadUint(bytes, 0);
             Debug.Assert(count > 0);
@@ -285,7 +285,7 @@ namespace MphRead.Formats.Sound
 
         public static IReadOnlyList<Sound3dEntry> ReadSound3dList()
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", "SND3DLIST.DAT");
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", "SND3DLIST.DAT");
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint count = Read.SpanReadUint(bytes, 0);
             Debug.Assert(count > 0);
@@ -294,7 +294,7 @@ namespace MphRead.Formats.Sound
 
         public static SoundTable ReadSoundTables()
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", "SNDTBLS.DAT");
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", "SNDTBLS.DAT");
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint count = Read.SpanReadUint(bytes, 0);
             Debug.Assert(count > 0);
@@ -314,7 +314,7 @@ namespace MphRead.Formats.Sound
 
         public static IReadOnlyList<RoomMusic> ReadAssignMusic()
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", "ASSIGNMUSIC.DAT");
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", "ASSIGNMUSIC.DAT");
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint count = Read.SpanReadUint(bytes, 0);
             Debug.Assert(count > 0);
@@ -323,7 +323,7 @@ namespace MphRead.Formats.Sound
 
         public static IReadOnlyList<MusicTrack> ReadInterMusicInfo()
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", "INTERMUSICINFO.DAT");
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", "INTERMUSICINFO.DAT");
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint count = Read.SpanReadUint(bytes, 0);
             Debug.Assert(count > 0);
@@ -338,7 +338,7 @@ namespace MphRead.Formats.Sound
 
         public static IReadOnlyList<SfxScriptFile> ReadSfxScriptFiles()
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", "SFXSCRIPTFILES.DAT");
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", "SFXSCRIPTFILES.DAT");
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint fileCount = Read.SpanReadUint(bytes, 0);
             Debug.Assert(fileCount > 0);
@@ -359,7 +359,7 @@ namespace MphRead.Formats.Sound
 
         public static IReadOnlyList<DgnFile> ReadDgnFiles()
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", "DGNFILES.DAT");
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", "DGNFILES.DAT");
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint fileCount = Read.SpanReadUint(bytes, 0);
             Debug.Assert(fileCount > 0);
@@ -409,7 +409,7 @@ namespace MphRead.Formats.Sound
 
         public static SoundData ReadSdat()
         {
-            string path = Path.Combine(Paths.FileSystem, "data", "sound", "sound_data.sdat");
+            string path = Paths.Combine(Paths.FileSystem, "data", "sound", "sound_data.sdat");
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             SdatHeader sdatHeader = Read.ReadStruct<SdatHeader>(bytes);
             Debug.Assert(sdatHeader.Type.MarshalString() == "SDAT");

--- a/src/MphRead/HUD/HudInfo.cs
+++ b/src/MphRead/HUD/HudInfo.cs
@@ -392,14 +392,14 @@ namespace MphRead.Hud
         public static (int, IReadOnlyList<ushort>) CharMapToTexture(string path, Scene scene,
             IReadOnlyList<ushort>? paletteOverride = null, int paletteId = -1)
         {
-            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(Paths.FileSystem, path)));
+            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(Paths.FileSystem, path)));
             return CharMapToTexture(bytes, startX: 0, startY: 0, tilesX: 0, tilesY: 0, scene, paletteOverride, paletteId);
         }
 
         public static (int, IReadOnlyList<ushort>) CharMapToTexture(string path, int startX, int startY,
             int tilesX, int tilesY, Scene scene, IReadOnlyList<ushort>? paletteOverride = null, int paletteId = -1)
         {
-            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(Paths.FileSystem, path)));
+            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(Paths.FileSystem, path)));
             return CharMapToTexture(bytes, startX, startY, tilesX, tilesY, scene, paletteOverride, paletteId);
         }
 
@@ -691,7 +691,7 @@ namespace MphRead.Hud
 
         public static HudObject GetHudObject(string file)
         {
-            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(Paths.FileSystem, file)));
+            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(Paths.FileSystem, file)));
             UiObjectHeader header = Read.ReadStruct<UiObjectHeader>(bytes);
             int offset = _objHeaderSize;
             Debug.Assert(header.ParamDataSize % _animParamSize == 0);
@@ -974,7 +974,7 @@ namespace MphRead.Hud
             }
             foreach (string file in files)
             {
-                var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(Paths.FileSystem, file)));
+                var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(Paths.FileSystem, file)));
                 UiObjectHeader header = Read.ReadStruct<UiObjectHeader>(bytes);
                 int offset = _objHeaderSize;
                 Debug.Assert(header.ParamDataSize % _animParamSize == 0);
@@ -1043,7 +1043,7 @@ namespace MphRead.Hud
                 //{
                 //    List<ColorRgba> character = characters[i];
                 //    string filename = $"{i.ToString().PadLeft(3, '0')}";
-                //    Export.Images.SaveTexture(Path.Combine(Paths.Export, "_ice"), filename, 8, 8, character);
+                //    Export.Images.SaveTexture(Paths.Combine(Paths.Export, "_ice"), filename, 8, 8, character);
                 //}
                 UiOamAttrs attrs = oamAttrs[0];
                 Debug.Assert(attrs.CharacterId == 0);
@@ -1094,7 +1094,7 @@ namespace MphRead.Hud
                             }
                         }
                         string dir = file.Replace("_archives/", "").Replace(".bin", "");
-                        dir = Path.Combine(Paths.Export, "_2D/Objects", dir, $"pal_{p.ToString().PadLeft(2, '0')}");
+                        dir = Paths.Combine(Paths.Export, "_2D/Objects", dir, $"pal_{p.ToString().PadLeft(2, '0')}");
                         //Directory.CreateDirectory(dir);
                         string name = i.ToString().PadLeft(3, '0');
                         //Export.Images.SaveTexture(dir, name, texWidth, texHeight, texture);
@@ -1185,7 +1185,7 @@ namespace MphRead.Hud
             };
             foreach (string file in files)
             {
-                var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(Paths.FileSystem, file)));
+                var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(Paths.FileSystem, file)));
                 UiPartHeader header = Read.ReadStruct<UiPartHeader>(bytes);
                 Debug.Assert(header.Magic == 0);
                 int offset = _layerHeaderSize;
@@ -1292,13 +1292,13 @@ namespace MphRead.Hud
                     }
                 }
                 string name = file.Replace("/", "--");
-                //Export.Images.SaveTexture(Path.Combine(Paths.Export, @"_2D\layertest"), name, width, height, texture);
+                //Export.Images.SaveTexture(Paths.Combine(Paths.Export, @"_2D\layertest"), name, width, height, texture);
 
                 for (int i = 0; i < characters.Count; i++)
                 {
                     List<ColorRgba> character = characters[i];
                     string filename = $"{i.ToString().PadLeft(3, '0')}";
-                    //Export.Images.SaveTexture(Path.Combine(Paths.Export, "_ice"), filename, 8, 8, character);
+                    //Export.Images.SaveTexture(Paths.Combine(Paths.Export, "_ice"), filename, 8, 8, character);
                 }
 
                 offset += info.ScrDataSize;

--- a/src/MphRead/Program.cs
+++ b/src/MphRead/Program.cs
@@ -8,7 +8,7 @@ namespace MphRead
 {
     internal static class Program
     {
-        public static Version Version { get; } = new Version(0, 23, 0, 0);
+        public static Version Version { get; } = new Version(0, 23, 1, 0);
         private static readonly Version _minExtractVersion = new Version(0, 19, 0, 0);
 
         private static void Main(string[] args)

--- a/src/MphRead/Program.cs
+++ b/src/MphRead/Program.cs
@@ -29,7 +29,7 @@ namespace MphRead
             }
             else if (arguments.Any(a => a.Name == "setup"))
             {
-                foreach (string path in Directory.EnumerateFiles(Path.Combine(Paths.FileSystem, "archives")))
+                foreach (string path in Directory.EnumerateFiles(Paths.Combine(Paths.FileSystem, "archives")))
                 {
                     Read.ExtractArchive(Path.GetFileNameWithoutExtension(path));
                 }

--- a/src/MphRead/Read.cs
+++ b/src/MphRead/Read.cs
@@ -128,7 +128,7 @@ namespace MphRead
             IReadOnlyList<RecolorMetadata> recolorMeta, bool firstHunt)
         {
             string root = firstHunt ? Paths.FhFileSystem : Paths.FileSystem;
-            string path = Path.Combine(root, modelPath);
+            string path = Paths.Combine(root, modelPath);
             ReadOnlySpan<byte> initialBytes = ReadBytes(path, firstHunt);
             Header header = ReadStruct<Header>(initialBytes[0..Sizes.Header]);
             IReadOnlyList<RawNode> nodes = DoOffsets<RawNode>(initialBytes, header.NodeOffset, header.NodeCount);
@@ -145,7 +145,7 @@ namespace MphRead
             {
                 ReadOnlySpan<byte> modelBytes = initialBytes;
                 Header modelHeader = header;
-                if (Path.Combine(root, meta.ModelPath) != path)
+                if (Paths.Combine(root, meta.ModelPath) != path)
                 {
                     modelBytes = ReadBytes(meta.ModelPath, firstHunt);
                     modelHeader = ReadStruct<Header>(modelBytes[0..Sizes.Header]);
@@ -389,7 +389,7 @@ namespace MphRead
             {
                 return results;
             }
-            path = Path.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path);
+            path = Paths.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path);
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             AnimationHeader header = ReadStruct<AnimationHeader>(bytes);
             IReadOnlyList<uint> nodeGroupOffsets = DoOffsets<uint>(bytes, header.NodeGroupOffset, header.Count);
@@ -554,7 +554,7 @@ namespace MphRead
 
         private static ReadOnlySpan<byte> ReadBytes(string path, bool firstHunt)
         {
-            return new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path)));
+            return new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path)));
         }
 
         private static IReadOnlyList<TextureData> GetTextureData(Texture texture, ReadOnlySpan<byte> textureBytes)
@@ -651,13 +651,13 @@ namespace MphRead
 
         public static IReadOnlyList<Entity> GetEntities(string path, int layerId, bool firstHunt)
         {
-            path = Path.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path);
+            path = Paths.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path);
             return GetEntitiesFromPath(path, layerId, firstHunt);
         }
 
         public static IReadOnlyList<Entity> GetEntitiesFromPath(string path, int layerId, bool firstHunt)
         {
-            path = Path.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path);
+            path = Paths.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, path);
             ReadOnlySpan<byte> bytes = ReadBytes(path, firstHunt);
             uint version = BitConverter.ToUInt32(bytes[0..4]);
             if (version == 1)
@@ -825,7 +825,7 @@ namespace MphRead
             {
                 return cached;
             }
-            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Path.Combine(Paths.FileSystem, path)));
+            var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(Paths.Combine(Paths.FileSystem, path)));
             RawEffect effect = ReadStruct<RawEffect>(bytes);
             var funcs = new Dictionary<uint, FxFuncInfo>();
             foreach (uint offset in DoOffsets<uint>(bytes, effect.FuncOffset, effect.FuncCount))
@@ -1197,7 +1197,7 @@ namespace MphRead
         public static void ExtractArchive(string path)
         {
             string name = Path.GetFileNameWithoutExtension(path);
-            string output = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path) ?? "", "..", "_archives", name));
+            string output = Path.GetFullPath(Paths.Combine(Path.GetDirectoryName(path) ?? "", "..", "_archives", name));
             try
             {
                 int filesWritten = 0;
@@ -1211,14 +1211,14 @@ namespace MphRead
                 }
                 else if (bytes[0] == LZ10.MagicByte)
                 {
-                    string temp = Path.Combine(Paths.Export, "__temp");
+                    string temp = Paths.Combine(Paths.Export, "__temp");
                     try
                     {
                         Directory.Delete(temp, recursive: true);
                     }
                     catch { }
                     Directory.CreateDirectory(temp);
-                    string destination = Path.Combine(temp, $"{name}.arc");
+                    string destination = Paths.Combine(temp, $"{name}.arc");
                     Console.Write(" Decompressing...");
                     LZ10.Decompress(path, destination);
                     Console.Write(" Extracting archive...");

--- a/src/MphRead/SceneSetup.cs
+++ b/src/MphRead/SceneSetup.cs
@@ -86,7 +86,7 @@ namespace MphRead
             NodeData? nodeData = null;
             if (metadata.NodePath != null)
             {
-                nodeData = ReadNodeData.ReadData(Path.Combine(@"", metadata.NodePath));
+                nodeData = ReadNodeData.ReadData(Paths.Combine(@"", metadata.NodePath));
             }
             room.Setup(metadata.Name, metadata, collision, nodeData, nodeLayerMask, metadata.Id);
             IReadOnlyList<EntityBase> entities = LoadEntities(metadata, entityLayerId, scene);

--- a/src/MphRead/Strings.cs
+++ b/src/MphRead/Strings.cs
@@ -19,7 +19,7 @@ namespace MphRead.Text
                 return table;
             }
             var entries = new List<StringTableEntry>();
-            string path = Path.Combine(Paths.FileSystem, GetFolder(language), name);
+            string path = Paths.Combine(Paths.FileSystem, GetFolder(language), name);
             var bytes = new ReadOnlySpan<byte>(File.ReadAllBytes(path));
             uint count = Read.SpanReadUint(bytes, 0);
             // ScanLog has an 8-byte header and 8 bytes between the last entry and first string,
@@ -217,7 +217,7 @@ namespace MphRead.Text
             }
             string prefix = downloadPlay ? "single_" : "";
             string name = $"{prefix}metroidhunters_text_{suffix}.bin";
-            string path = Path.Combine(Paths.FileSystem, "frontend", name);
+            string path = Paths.Combine(Paths.FileSystem, "frontend", name);
             if (suffix == "en-gb")
             {
                 path = path.Replace("amhe0", "amhp1");

--- a/src/MphRead/Test.cs
+++ b/src/MphRead/Test.cs
@@ -25,8 +25,8 @@ namespace MphRead
         public static void TestModelFiles()
         {
             var paths = new List<string>();
-            paths.AddRange(Directory.EnumerateFiles(Path.Combine(Paths.FileSystem, "models")).Where(f => f.EndsWith("odel.bin")));
-            paths.AddRange(Directory.EnumerateFiles(Path.Combine(Paths.FileSystem, "_archives"), "", SearchOption.AllDirectories)
+            paths.AddRange(Directory.EnumerateFiles(Paths.Combine(Paths.FileSystem, "models")).Where(f => f.EndsWith("odel.bin")));
+            paths.AddRange(Directory.EnumerateFiles(Paths.Combine(Paths.FileSystem, "_archives"), "", SearchOption.AllDirectories)
                 .Where(f => f.EndsWith("odel.bin")));
             var headers = new Dictionary<string, Header>();
             foreach (string path in paths)
@@ -288,7 +288,7 @@ namespace MphRead
 
         private static void WriteAllModels()
         {
-            string modelPath = Path.Combine(Paths.FileSystem, "models");
+            string modelPath = Paths.Combine(Paths.FileSystem, "models");
             var modelFiles = new List<string>();
             var textureFiles = new List<string>();
             var animationFiles = new List<string>();

--- a/src/MphRead/Testing/TestMisc.cs
+++ b/src/MphRead/Testing/TestMisc.cs
@@ -57,7 +57,7 @@ namespace MphRead.Testing
 
         public static void TestCameraSequenceFiles()
         {
-            foreach (string filePath in Directory.EnumerateFiles(Path.Combine(Paths.FileSystem, "cameraEditor")))
+            foreach (string filePath in Directory.EnumerateFiles(Paths.Combine(Paths.FileSystem, "cameraEditor")))
             {
                 string name = Path.GetFileName(filePath);
                 if (name != "cameraEditBG.bin")
@@ -138,25 +138,25 @@ namespace MphRead.Testing
                 overMeta = Metadata.RoomMetadata[over];
             }
             Debug.Assert(meta.EntityPath != null && meta.NodePath != null);
-            string folder = Path.Combine(Paths.Export, "_pack");
+            string folder = Paths.Combine(Paths.Export, "_pack");
             string fileSystem = meta.FirstHunt ? Paths.FhFileSystem : Paths.FileSystem;
             Console.WriteLine("Converting model...");
             // model, texure
             (byte[] model, byte[] texture) = Repack.RepackRoomModel(room, separateTextures: true);
             string modelPath = Path.GetFileName(overMeta?.ModelPath ?? meta.ModelPath);
-            string modelDest = Path.Combine(folder, modelPath);
-            string texDest = Path.Combine(folder, modelPath.Replace("_Model.bin", "_Tex.bin").Replace("_model.bin", "_tex.bin"));
+            string modelDest = Paths.Combine(folder, modelPath);
+            string texDest = Paths.Combine(folder, modelPath.Replace("_Model.bin", "_Tex.bin").Replace("_model.bin", "_tex.bin"));
             File.WriteAllBytes(modelDest, model);
             File.WriteAllBytes(texDest, texture);
             Console.WriteLine("Converting collision...");
             // collision
             byte[] collision = RepackCollision.RepackMphRoom(room);
-            string colDest = Path.Combine(folder, Path.GetFileName(overMeta?.CollisionPath ?? meta.CollisionPath));
+            string colDest = Paths.Combine(folder, Path.GetFileName(overMeta?.CollisionPath ?? meta.CollisionPath));
             File.WriteAllBytes(colDest, collision);
             Console.WriteLine("Converting animation...");
             // animation
-            string animSrc = Path.Combine(fileSystem, meta.AnimationPath);
-            string animDest = Path.Combine(folder, Path.GetFileName(overMeta?.AnimationPath ?? meta.AnimationPath));
+            string animSrc = Paths.Combine(fileSystem, meta.AnimationPath);
+            string animDest = Paths.Combine(folder, Path.GetFileName(overMeta?.AnimationPath ?? meta.AnimationPath));
             File.Delete(animDest);
             File.Copy(animSrc, animDest);
             //entity, nodedata
@@ -164,15 +164,15 @@ namespace MphRead.Testing
             {
                 Console.WriteLine("Copying entities...");
                 Console.WriteLine("Copying nodedata...");
-                string entSrc = Path.Combine(fileSystem, meta.EntityPath);
-                string nodeSrc = Path.Combine(fileSystem, meta.NodePath);
-                string entDest = Path.Combine(folder, meta.EntityPath);
-                string nodeDest = Path.Combine(folder, meta.NodePath);
+                string entSrc = Paths.Combine(fileSystem, meta.EntityPath);
+                string nodeSrc = Paths.Combine(fileSystem, meta.NodePath);
+                string entDest = Paths.Combine(folder, meta.EntityPath);
+                string nodeDest = Paths.Combine(folder, meta.NodePath);
                 if (overMeta != null)
                 {
                     Debug.Assert(overMeta.EntityPath != null && overMeta.NodePath != null);
-                    entDest = Path.Combine(folder, overMeta.EntityPath);
-                    nodeDest = Path.Combine(folder, overMeta.NodePath);
+                    entDest = Paths.Combine(folder, overMeta.EntityPath);
+                    nodeDest = Paths.Combine(folder, overMeta.NodePath);
                 }
                 File.Delete(entDest);
                 File.Delete(nodeDest);
@@ -183,7 +183,7 @@ namespace MphRead.Testing
             {
                 Console.WriteLine("Converting entities...");
                 byte[] entity = Repack.RepackMphEntities(room);
-                string entDest = Path.Combine(folder, Path.GetFileName(overMeta?.EntityPath ?? meta.EntityPath));
+                string entDest = Paths.Combine(folder, Path.GetFileName(overMeta?.EntityPath ?? meta.EntityPath));
                 File.WriteAllBytes(entDest, entity);
                 // todo: nodedata
             }
@@ -195,7 +195,7 @@ namespace MphRead.Testing
                 colDest,
                 modelDest
             };
-            string outPath = Path.Combine(folder, "out.arc");
+            string outPath = Paths.Combine(folder, "out.arc");
             Archive.Archiver.Archive(outPath, files);
             string archiveName = overMeta?.Archive ?? meta.Archive;
             Console.WriteLine(" Compressing...");
@@ -214,7 +214,7 @@ namespace MphRead.Testing
                 overMeta = Metadata.RoomMetadata[over];
             }
             Debug.Assert(meta.EntityPath != null && meta.NodePath != null);
-            string folder = Path.Combine(Paths.Export, "_pack");
+            string folder = Paths.Combine(Paths.Export, "_pack");
             string fileSystem = meta.FirstHunt ? Paths.FhFileSystem : Paths.FileSystem;
             RepackFilter filter = RepackFilter.All;
             if (!meta.FirstHunt && !meta.Hybrid)
@@ -225,17 +225,17 @@ namespace MphRead.Testing
             // model, texure
             (byte[] model, _) = Repack.RepackRoomModel(room, separateTextures: false, filter);
             string modelPath = Path.GetFileName(overMeta?.ModelPath ?? meta.ModelPath);
-            string modelDest = Path.Combine(folder, modelPath);
+            string modelDest = Paths.Combine(folder, modelPath);
             File.WriteAllBytes(modelDest, model);
             Console.WriteLine("Converting collision...");
             // collision
             byte[] collision = RepackCollision.RepackFhRoom(room, filter);
-            string colDest = Path.Combine(folder, Path.GetFileName(overMeta?.CollisionPath ?? meta.CollisionPath));
+            string colDest = Paths.Combine(folder, Path.GetFileName(overMeta?.CollisionPath ?? meta.CollisionPath));
             File.WriteAllBytes(colDest, collision);
             Console.WriteLine("Converting animation...");
             // animation
-            string animSrc = Path.Combine(fileSystem, meta.AnimationPath);
-            string animDest = Path.Combine(folder, Path.GetFileName(overMeta?.AnimationPath ?? meta.AnimationPath));
+            string animSrc = Paths.Combine(fileSystem, meta.AnimationPath);
+            string animDest = Paths.Combine(folder, Path.GetFileName(overMeta?.AnimationPath ?? meta.AnimationPath));
             File.Delete(animDest);
             File.Copy(animSrc, animDest);
             //entity, nodedata
@@ -243,15 +243,15 @@ namespace MphRead.Testing
             {
                 Console.WriteLine("Copying entities...");
                 Console.WriteLine("Copying nodedata...");
-                string entSrc = Path.Combine(fileSystem, meta.EntityPath);
-                string nodeSrc = Path.Combine(fileSystem, meta.NodePath);
-                string entDest = Path.Combine(folder, meta.EntityPath);
-                string nodeDest = Path.Combine(folder, meta.NodePath);
+                string entSrc = Paths.Combine(fileSystem, meta.EntityPath);
+                string nodeSrc = Paths.Combine(fileSystem, meta.NodePath);
+                string entDest = Paths.Combine(folder, meta.EntityPath);
+                string nodeDest = Paths.Combine(folder, meta.NodePath);
                 if (overMeta != null)
                 {
                     Debug.Assert(overMeta.EntityPath != null && overMeta.NodePath != null);
-                    entDest = Path.Combine(folder, overMeta.EntityPath);
-                    nodeDest = Path.Combine(folder, overMeta.NodePath);
+                    entDest = Paths.Combine(folder, overMeta.EntityPath);
+                    nodeDest = Paths.Combine(folder, overMeta.NodePath);
                 }
                 File.Delete(entDest);
                 File.Delete(nodeDest);
@@ -262,7 +262,7 @@ namespace MphRead.Testing
             {
                 Console.WriteLine("Converting entities...");
                 byte[] entity = Repack.RepackFhEntities(room, filter);
-                string entDest = Path.Combine(folder, Path.GetFileName(overMeta?.EntityPath ?? meta.EntityPath));
+                string entDest = Paths.Combine(folder, Path.GetFileName(overMeta?.EntityPath ?? meta.EntityPath));
                 File.WriteAllBytes(entDest, entity);
                 // todo: nodedata
             }

--- a/src/MphRead/Testing/TestOverlay.cs
+++ b/src/MphRead/Testing/TestOverlay.cs
@@ -9,8 +9,8 @@ namespace MphRead.Testing
     {
         public static void CompareGames(string game1, string game2)
         {
-            string root1 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1);
-            string root2 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2);
+            string root1 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1);
+            string root2 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2);
             var dirs1 = Directory.EnumerateDirectories(root1, "", SearchOption.AllDirectories)
                 .Select(d => d.Replace(root1, "")).ToList();
             var dirs2 = Directory.EnumerateDirectories(root2, "", SearchOption.AllDirectories)
@@ -20,7 +20,7 @@ namespace MphRead.Testing
             foreach (string dir in dirs1)
             {
                 files1.Add(dir, new List<string>());
-                foreach (string file in Directory.EnumerateFiles(Path.Combine(root1, dir)))
+                foreach (string file in Directory.EnumerateFiles(Paths.Combine(root1, dir)))
                 {
                     files1[dir].Add(Path.GetFileName(file));
                 }
@@ -28,7 +28,7 @@ namespace MphRead.Testing
             foreach (string dir in dirs2)
             {
                 files2.Add(dir, new List<string>());
-                foreach (string file in Directory.EnumerateFiles(Path.Combine(root2, dir)))
+                foreach (string file in Directory.EnumerateFiles(Paths.Combine(root2, dir)))
                 {
                     files2[dir].Add(Path.GetFileName(file));
                 }
@@ -87,8 +87,8 @@ namespace MphRead.Testing
                 var changes = new List<string>();
                 foreach (string file in files1[dir].Where(d => files2[dir].Contains(d)))
                 {
-                    byte[] bytes1 = File.ReadAllBytes(Path.Combine(root1, dir, file));
-                    byte[] bytes2 = File.ReadAllBytes(Path.Combine(root2, dir, file));
+                    byte[] bytes1 = File.ReadAllBytes(Paths.Combine(root1, dir, file));
+                    byte[] bytes2 = File.ReadAllBytes(Paths.Combine(root2, dir, file));
                     if (!Enumerable.SequenceEqual(bytes1, bytes2))
                     {
                         changes.Add(file);

--- a/src/MphRead/Utility/Archive.cs
+++ b/src/MphRead/Utility/Archive.cs
@@ -122,7 +122,7 @@ namespace MphRead.Archive
                 string filename = file.Filename.MarshalString();
                 int start = (int)file.Offset;
                 int end = start + (int)file.TargetFileSize;
-                string output = Path.Combine(destination!, filename);
+                string output = Paths.Combine(destination!, filename);
                 File.WriteAllBytes(output, bytes[start..end].ToArray());
                 filesWritten++;
             }

--- a/src/MphRead/Utility/Extract.cs
+++ b/src/MphRead/Utility/Extract.cs
@@ -66,11 +66,11 @@ namespace MphRead
             string newPath;
             if (isFh)
             {
-                newPath = Path.GetFullPath(Path.Combine("files", rootName, "data"));
+                newPath = Path.GetFullPath(Paths.Combine("files", rootName, "data"));
             }
             else
             {
-                newPath = Path.GetFullPath(Path.Combine("files", rootName));
+                newPath = Path.GetFullPath(Paths.Combine("files", rootName));
             }
             Paths.SetPath(rootName, newPath);
             var lines = new List<string>();
@@ -124,8 +124,8 @@ namespace MphRead
             {
                 return;
             }
-            byte[] bytes = File.ReadAllBytes(Path.Combine("files", rootName, "_bin", data.FontModel.File));
-            File.WriteAllBytes(Path.Combine("files", rootName, @"models\hudfont_Model.bin"),
+            byte[] bytes = File.ReadAllBytes(Paths.Combine("files", rootName, "_bin", data.FontModel.File));
+            File.WriteAllBytes(Paths.Combine("files", rootName, @"models\hudfont_Model.bin"),
                 bytes[data.FontModel.Offset..(data.FontModel.Offset + data.FontModel.Size)]);
         }
 
@@ -181,19 +181,19 @@ namespace MphRead
                 {
                     (int start, int end) = fileOffsets[(int)file.Index];
                     Debug.Assert(start > 0 && end > start);
-                    File.WriteAllBytes(Path.Combine(path, file.Name), bytes[start..end]);
+                    File.WriteAllBytes(Paths.Combine(path, file.Name), bytes[start..end]);
                 }
                 foreach (DirInfo subdir in dir.Subdirectories)
                 {
-                    WriteFiles(subdir, Path.Combine(path, subdir.Name));
+                    WriteFiles(subdir, Paths.Combine(path, subdir.Name));
                 }
             }
             var root = new DirInfo(rootName, index: 0);
             PopulateDir(root);
-            WriteFiles(root, Path.Combine("files", root.Name));
+            WriteFiles(root, Paths.Combine("files", root.Name));
             if (hasArchives)
             {
-                foreach (string path in Directory.EnumerateFiles(Path.Combine("files", root.Name, "archives")))
+                foreach (string path in Directory.EnumerateFiles(Paths.Combine("files", root.Name, "archives")))
                 {
                     if (Path.GetExtension(path).ToLower() == ".arc")
                     {
@@ -201,12 +201,12 @@ namespace MphRead
                     }
                 }
             }
-            string ftcDir = Path.Combine("files", root.Name, "ftc");
+            string ftcDir = Paths.Combine("files", root.Name, "ftc");
             Directory.CreateDirectory(ftcDir);
             byte[] WriteFile(string name, int offset, int size)
             {
                 byte[] fileBytes = bytes[offset..(offset + size)];
-                File.WriteAllBytes(Path.Combine(ftcDir, name), fileBytes);
+                File.WriteAllBytes(Paths.Combine(ftcDir, name), fileBytes);
                 return fileBytes;
             }
             WriteFile("arm9.bin", header.ARM9Offset, header.ARM9Size);
@@ -229,9 +229,9 @@ namespace MphRead
                 int fileId = items[6];
                 (int overlayStart, int overlayEnd) = fileOffsets[fileId];
                 Debug.Assert(overlayStart > 0 && overlayEnd > overlayStart);
-                File.WriteAllBytes(Path.Combine(ftcDir, $"overlay9_{overlayId}"), bytes[overlayStart..overlayEnd]);
+                File.WriteAllBytes(Paths.Combine(ftcDir, $"overlay9_{overlayId}"), bytes[overlayStart..overlayEnd]);
             }
-            string ftcDest = Path.Combine("files", root.Name, "_bin");
+            string ftcDest = Paths.Combine("files", root.Name, "_bin");
             Directory.CreateDirectory(ftcDest);
             foreach (string path in Directory.EnumerateFiles(ftcDir))
             {
@@ -239,7 +239,7 @@ namespace MphRead
                 if (filename == "arm9.bin" || filename.StartsWith("overlay9_"))
                 {
                     Console.WriteLine($"Decompressing {filename}...");
-                    LZBackward.Decompress(path, Path.Combine(ftcDest, filename));
+                    LZBackward.Decompress(path, Paths.Combine(ftcDest, filename));
                 }
             }
             Nop();
@@ -335,7 +335,7 @@ namespace MphRead
                 return;
             }
             // arm9.bin
-            byte[] bytes = File.ReadAllBytes(Path.Combine(Paths.FileSystem, "_bin", data.FontWidths.File));
+            byte[] bytes = File.ReadAllBytes(Paths.Combine(Paths.FileSystem, "_bin", data.FontWidths.File));
             byte[] widths = bytes[data.FontWidths.Offset..(data.FontWidths.Offset + data.FontWidths.Size)];
             byte[] offsets = bytes[data.FontOffsets.Offset..(data.FontOffsets.Offset + data.FontOffsets.Size)];
             byte[] chars = bytes[data.FontCharData.Offset..(data.FontCharData.Offset + data.FontCharData.Size)];
@@ -343,7 +343,7 @@ namespace MphRead
             byte[] enemyDeathSfx = bytes[data.EnemyDeathSfx.Offset..(data.EnemyDeathSfx.Offset + data.EnemyDeathSfx.Size)];
             Text.Font.SetData(widths, offsets, chars);
             // overlay9_2
-            bytes = File.ReadAllBytes(Path.Combine(Paths.FileSystem, "_bin", data.BeamSfx.File));
+            bytes = File.ReadAllBytes(Paths.Combine(Paths.FileSystem, "_bin", data.BeamSfx.File));
             byte[] terrainSfx = bytes[data.TerrianSfx.Offset..(data.TerrianSfx.Offset + data.TerrianSfx.Size)];
             byte[] beamSfx = bytes[data.BeamSfx.Offset..(data.BeamSfx.Offset + data.BeamSfx.Size)];
             byte[] hunterSfx = bytes[data.HunterSfx.Offset..(data.HunterSfx.Offset + data.HunterSfx.Size)];
@@ -353,7 +353,7 @@ namespace MphRead
             Metadata.SetEnemyDamageSfxData(enemyDamageSfx);
             Metadata.SetEnemyDeathSfxData(enemyDeathSfx);
             // overlay9_15 (or overlay9_12 for A76E0)
-            bytes = File.ReadAllBytes(Path.Combine(Paths.FileSystem, "_bin", data.PlatformSfx.File));
+            bytes = File.ReadAllBytes(Paths.Combine(Paths.FileSystem, "_bin", data.PlatformSfx.File));
             byte[] platformSfx = bytes[data.PlatformSfx.Offset..(data.PlatformSfx.Offset + data.PlatformSfx.Size)];
             Metadata.SetPlatformSfxData(platformSfx);
         }

--- a/src/MphRead/Utility/Parser.cs
+++ b/src/MphRead/Utility/Parser.cs
@@ -130,7 +130,7 @@ namespace MphRead.Utility
             while (true)
             {
                 Console.Clear();
-                Console.WriteLine("1: POLYGON_ATTR\r\nx: quit");
+                Console.WriteLine($"1: POLYGON_ATTR{Environment.NewLine}x: quit");
                 string? type = null;
                 string input = Console.ReadLine() ?? "";
                 if (input == "x" || input == "X")

--- a/src/MphRead/Utility/RepackCollision.cs
+++ b/src/MphRead/Utility/RepackCollision.cs
@@ -132,8 +132,8 @@ namespace MphRead.Utility
                 List<CollisionDataEditor> editors = GetEditors(collision);
                 byte[] bytes = RepackMphCollision(editors, collision.Info.Portals);
                 //byte[] bytes = RepackMphCollisionSimple(info);
-                //byte[] file = File.ReadAllBytes(Path.Combine(Paths.FileSystem, path));
-                string outPath = Path.Combine(Paths.Export, "_pack", $"out_{Path.GetFileName(path)}");
+                //byte[] file = File.ReadAllBytes(Paths.Combine(Paths.FileSystem, path));
+                string outPath = Paths.Combine(Paths.Export, "_pack", $"out_{Path.GetFileName(path)}");
                 File.WriteAllBytes(outPath, bytes);
                 //CompareCollision(info, bytes, file);
             }

--- a/src/MphRead/Utility/RepackEntity.cs
+++ b/src/MphRead/Utility/RepackEntity.cs
@@ -61,7 +61,7 @@ namespace MphRead.Utility
             //    entities.Add(entity);
             //}
             byte[] bytes = meta.FirstHunt ? RepackFhEntities(entities) : RepackEntities(entities);
-            string path = Path.Combine(Paths.Export, "_pack", Path.GetFileName(entityPath));
+            string path = Paths.Combine(Paths.Export, "_pack", Path.GetFileName(entityPath));
             File.WriteAllBytes(path, bytes);
             Nop();
             return bytes;
@@ -79,7 +79,7 @@ namespace MphRead.Utility
                 {
                     IReadOnlyList<EntityEditorBase> entities = GetFhEntities(meta.EntityPath);
                     byte[] bytes = RepackFhEntities(entities);
-                    byte[] fileBytes = File.ReadAllBytes(Path.Combine(Paths.FhFileSystem, meta.EntityPath));
+                    byte[] fileBytes = File.ReadAllBytes(Paths.Combine(Paths.FhFileSystem, meta.EntityPath));
                     CompareFhEntities(bytes, fileBytes);
                     Nop();
                 }
@@ -87,7 +87,7 @@ namespace MphRead.Utility
                 {
                     IReadOnlyList<EntityEditorBase> entities = GetEntities(meta.EntityPath);
                     byte[] bytes = RepackEntities(entities);
-                    byte[] fileBytes = File.ReadAllBytes(Path.Combine(Paths.FileSystem, meta.EntityPath));
+                    byte[] fileBytes = File.ReadAllBytes(Paths.Combine(Paths.FileSystem, meta.EntityPath));
                     CompareEntities(bytes, fileBytes);
                     Nop();
                 }
@@ -1036,13 +1036,13 @@ namespace MphRead.Utility
             string path2;
             if (meta1.FirstHunt)
             {
-                path1 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1, "data", meta1.EntityPath);
-                path2 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2, "data", meta2.EntityPath);
+                path1 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1, "data", meta1.EntityPath);
+                path2 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2, "data", meta2.EntityPath);
             }
             else
             {
-                path1 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1, meta1.EntityPath);
-                path2 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2, meta2.EntityPath);
+                path1 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1, meta1.EntityPath);
+                path2 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2, meta2.EntityPath);
             }
             byte[] bytes1 = File.ReadAllBytes(path1);
             byte[] bytes2 = File.ReadAllBytes(path2);

--- a/src/MphRead/Utility/RepackModel.cs
+++ b/src/MphRead/Utility/RepackModel.cs
@@ -165,11 +165,11 @@ namespace MphRead.Utility
             }
             bool fhPad = animPath.EndsWith("testlevel_Anim.bin");
             byte[] bytes = PackAnim(node, mat, uv, tex, fhPad);
-            byte[] fileBytes = File.ReadAllBytes(Path.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, animPath));
+            byte[] fileBytes = File.ReadAllBytes(Paths.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, animPath));
             CompareAnims(model.Name, bytes, fileBytes);
             if (writeFile)
             {
-                File.WriteAllBytes(Path.Combine(Paths.Export, "_pack", $"out_{model.Name}_Anim.bin"), bytes);
+                File.WriteAllBytes(Paths.Combine(Paths.Export, "_pack", $"out_{model.Name}_Anim.bin"), bytes);
             }
             Nop();
         }
@@ -196,24 +196,24 @@ namespace MphRead.Utility
             Debug.Assert(model.Scale.X == (int)model.Scale.X);
             (byte[] bytes, byte[] tex) = PackModel((int)model.Scale.X, model.NodeMatrixIds, model.NodePosCounts, model.Materials,
                 textureInfo, paletteInfo, model.Nodes, model.Meshes, model.RenderInstructionLists, model.DisplayLists, options);
-            byte[] fileBytes = File.ReadAllBytes(Path.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, modelPath));
+            byte[] fileBytes = File.ReadAllBytes(Paths.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, modelPath));
             if (options.Compare)
             {
                 CompareModels(model.Name, bytes, fileBytes, options);
                 if (options.Texture == RepackTexture.Separate)
                 {
                     Debug.Assert(texPath != null);
-                    byte[] texFile = File.ReadAllBytes(Path.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, texPath));
+                    byte[] texFile = File.ReadAllBytes(Paths.Combine(firstHunt ? Paths.FhFileSystem : Paths.FileSystem, texPath));
                     Debug.Assert(tex.Length == texFile.Length);
                     Debug.Assert(Enumerable.SequenceEqual(tex, texFile));
                 }
             }
             if (options.WriteFile)
             {
-                File.WriteAllBytes(Path.Combine(Paths.Export, "_pack", $"out_{model.Name}_{model.Recolors[recolor].Name}.bin"), bytes);
+                File.WriteAllBytes(Paths.Combine(Paths.Export, "_pack", $"out_{model.Name}_{model.Recolors[recolor].Name}.bin"), bytes);
                 if (options.Texture == RepackTexture.Separate)
                 {
-                    File.WriteAllBytes(Path.Combine(Paths.Export, "_pack", $"out_{model.Name}_Tex.bin"), tex);
+                    File.WriteAllBytes(Paths.Combine(Paths.Export, "_pack", $"out_{model.Name}_Tex.bin"), tex);
                 }
             }
             Nop();
@@ -223,8 +223,8 @@ namespace MphRead.Utility
         {
             ModelMetadata meta1 = Metadata.ModelMetadata[model1];
             ModelMetadata meta2 = Metadata.ModelMetadata[model2];
-            string path1 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1, meta1.ModelPath);
-            string path2 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2, meta2.ModelPath);
+            string path1 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1, meta1.ModelPath);
+            string path2 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2, meta2.ModelPath);
             CompareModels(model1, File.ReadAllBytes(path1), File.ReadAllBytes(path2), new RepackOptions()
             {
                 Texture = RepackTexture.Separate
@@ -238,8 +238,8 @@ namespace MphRead.Utility
             ModelMetadata meta2 = Metadata.ModelMetadata[model2];
             if (meta1.AnimationPath != null && meta2.AnimationPath != null)
             {
-                string path1 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1, meta1.AnimationPath);
-                string path2 = Path.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2, meta2.AnimationPath);
+                string path1 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game1, meta1.AnimationPath);
+                string path2 = Paths.Combine(Path.GetDirectoryName(Paths.FileSystem) ?? "", game2, meta2.AnimationPath);
                 CompareAnims(model1, File.ReadAllBytes(path1), File.ReadAllBytes(path2));
             }
             Nop();


### PR DESCRIPTION
- Replace `Path.Combine()` with a helper that ensures there are no mixed separators in the path
- Update a couple places where newlines were assumed to be `\r\n`