### PR TITLE
Merge develop (0.34.1.0)

### DIFF
--- a/src/MphRead/Program.cs
+++ b/src/MphRead/Program.cs
@@ -10,7 +10,7 @@ namespace MphRead
 {
     internal static class Program
     {
-        public static Version Version { get; } = new Version(0, 34, 0, 0);
+        public static Version Version { get; } = new Version(0, 34, 1, 0);
         private static readonly Version _minExtractVersion = new Version(0, 19, 0, 0);
 
         private static void Main(string[] args)

--- a/src/MphRead/Utility/Extract.cs
+++ b/src/MphRead/Utility/Extract.cs
@@ -47,6 +47,7 @@ namespace MphRead
                 PrintExit($"The specified {gameCode} ROM has unexpected version {header.Version}.");
                 return;
             }
+            Paths.UpdatePaths();
             if (File.Exists("paths.txt"))
             {
                 if ((!isFh && !String.IsNullOrWhiteSpace(Paths.FileSystem))


### PR DESCRIPTION
- Fix uninitialized path setup during first-time ROM extraction.

Fixes #157.