### PR TITLE
Fix SFX listener position bug

### DIFF
--- a/src/MphRead/Sound/Sfx.cs
+++ b/src/MphRead/Sound/Sfx.cs
@@ -480,7 +480,7 @@ namespace MphRead.Sound
             }
             if (_scene.CameraMode == CameraMode.Player)
             {
-                return PlayerEntity.Main.CameraInfo.UpVector;
+                return PlayerEntity.Main.CameraInfo.TrueUp;
             }
             return _scene.ViewMatrix.Row1.Xyz.Normalized();
         }


### PR DESCRIPTION
- Use true (perpendicular) up vector for player listener position, not the one that's always unit Y.